### PR TITLE
Feat: Add email template

### DIFF
--- a/email.html
+++ b/email.html
@@ -856,13 +856,12 @@
                         <table align="center" border="0" cellspacing="0" cellpadding="0" width="600" style="width:600px;">
                         <tr>
                         <td align="center" valign="top" width="600" style="width:600px;">
-                        <![endif]-->
+					<![endif]-->
 					<table border="0" cellpadding="0" cellspacing="0" width="100%" class="templateContainer">
 						<tr>
 							<td valign="top" id="templateHeader">
 								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnBoxedTextBlock"
 									style="min-width:100%;">
-
 								</table>
 								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnImageBlock"
 									style="min-width:100%;">
@@ -876,44 +875,16 @@
 														<tr>
 															<td class="mcnImageContent" valign="top"
 																style="padding-right: 9px; padding-left: 9px; padding-top: 0; padding-bottom: 0; text-align:center;">
-
-
 																<img align="center"
 																	alt="Logo of the Massachusetts Bay Transportation Authority"
 																	src="https://gallery.mailchimp.com/d69747d5fc9f30fa7321ea932/images/bcf766a9-2f0e-4ac7-88ff-d303e92c9056.png"
 																	width="564"
 																	style="max-width:979px; padding-bottom: 0; display: inline !important; vertical-align: bottom;"
 																	class="mcnImage">
-
-
 															</td>
 														</tr>
 													</tbody>
 												</table>
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
-									style="min-width:100%;">
-									<tbody class="mcnDividerBlockOuter">
-										<tr>
-											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
-												<table class="mcnDividerContent" border="0" cellpadding="0"
-													cellspacing="0" width="100%"
-													style="min-width: 100%;border-top: 2px none #EAEAEA;">
-													<tbody>
-														<tr>
-															<td>
-																<span></span>
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--            
-                <td class="mcnDividerBlockInner" style="padding: 18px;">
-                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
--->
 											</td>
 										</tr>
 									</tbody>
@@ -928,46 +899,46 @@
 										<tr>
 											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
 												<!--[if mso]>
-				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
-				<tr>
-				<![endif]-->
+													<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+													<tr>
+												<![endif]-->
 
 												<!--[if mso]>
-				<td valign="top" width="600" style="width:600px;">
-				<![endif]-->
+													<td valign="top" width="600" style="width:600px;">
+												<![endif]-->
 												<table align="left" border="0" cellpadding="0" cellspacing="0"
 													style="max-width:100%; min-width:100%;" width="100%"
 													class="mcnTextContentContainer">
 													<tbody>
 														<tr>
-
 															<td valign="top" class="mcnTextContent"
-																style="padding: 0px 18px 9px; font-family: &quot;Helvetica Neue&quot;, Helvetica, Arial, Verdana, sans-serif;">
+																style="padding: 0px 18px 9px; font-family: 'Helvetica Neue', Helvetica, Arial, Verdana, sans-serif;">
 
 																<p dir="ltr"
-																	style="font-family: &quot;Helvetica Neue&quot;, Helvetica, Arial, Verdana, sans-serif;">
-																	<span style="font-size:18px"><span
-																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Hi
-																			all,<br>
+																	style="font-family: 'Helvetica Neue', Helvetica, Arial, Verdana, sans-serif;">
+																	<span style="font-size:18px">
+																		<span style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">
 																			<br>
 																			As we enter the end of summer, we wanted to
 																			take the opportunity to share some important
 																			information about how the MBTA is ensuring
 																			that our services remain both safe and
-																			accessible.</span></span></p>
-
+																			accessible.
+																		</span>
+																	</span>
+																</p>
 															</td>
 														</tr>
 													</tbody>
 												</table>
-												<!--[if mso]>
-				</td>
-				<![endif]-->
+											<!--[if mso]>
+												</td>
+											<![endif]-->
 
-												<!--[if mso]>
-				</tr>
-				</table>
-				<![endif]-->
+											<!--[if mso]>
+												</tr>
+												</table>
+											<![endif]-->
 											</td>
 										</tr>
 									</tbody>
@@ -978,812 +949,48 @@
 										<tr>
 											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
 												<!--[if mso]>
-				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
-				<tr>
-				<![endif]-->
+													<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+													<tr>
+												<![endif]-->
 
 												<!--[if mso]>
-				<td valign="top" width="600" style="width:600px;">
-				<![endif]-->
+													<td valign="top" width="600" style="width:600px;">
+												<![endif]-->
 												<table align="left" border="0" cellpadding="0" cellspacing="0"
 													style="max-width:100%; min-width:100%;" width="100%"
 													class="mcnTextContentContainer">
 													<tbody>
 														<tr>
-
 															<td valign="top" class="mcnTextContent"
 																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
-
 																<h1 class="null" dir="ltr">Ride Safer</h1>
-
-																<p dir="ltr"><span style="font-size:18px"><span
-																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Check
-																			out <a href="http://www.mbta.com/ridesafer"
-																				target="_blank">mbta.com/ridesafer</a>&nbsp;for
+																<p dir="ltr">
+																	<span style="font-size:18px">
+																		<span style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Check
+																			out <a href="http://www.mbta.com/ridesafer" target="_blank">mbta.com/ridesafer</a>&nbsp;for
 																			a collection of updates and frequently asked
 																			questions about the measures we've taken in
-																			response&nbsp;to COVID-19.</span></span></p>
-
+																			response&nbsp;to COVID-19.
+																		</span>
+																	</span>
+																</p>
 															</td>
 														</tr>
 													</tbody>
 												</table>
-												<!--[if mso]>
-				</td>
-				<![endif]-->
-
-												<!--[if mso]>
-				</tr>
-				</table>
-				<![endif]-->
+											<!--[if mso]>
 											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%"
-									class="mcnImageCardBlock">
-									<tbody class="mcnImageCardBlockOuter">
-										<tr>
-											<td class="mcnImageCardBlockInner" valign="top"
-												style="padding-top:9px; padding-right:18px; padding-bottom:9px; padding-left:18px;">
-
-												<table align="right" border="0" cellpadding="0" cellspacing="0"
-													class="mcnImageCardBottomContent" width="100%"
-													style="background-color: #404040;">
-													<tbody>
-														<tr>
-															<td class="mcnImageCardBottomImageContent" align="left"
-																valign="top"
-																style="padding-top:0px; padding-right:0px; padding-bottom:0; padding-left:0px;">
-
-
-																<a href="https://www.youtube.com/watch?v=4Mu-YvdyDKM"
-																	title="" class="" target="">
-
-
-																	<img alt=""
-																		src="https://mcusercontent.com/d69747d5fc9f30fa7321ea932/video_thumbnails_new/b6e9f9791b462542c4fae53e4be54294.png"
-																		width="564" style="max-width:640px;"
-																		class="mcnImage">
-																</a>
-
-															</td>
-														</tr>
-														<tr>
-															<td class="mcnTextContent" valign="top"
-																style="padding: 9px 18px;color: #F2F2F2;font-family: Helvetica;font-size: 14px;font-weight: normal;text-align: center;"
-																width="546">
-																As service increases and more riders return to taking
-																the T, we all must share the responsibility of
-																protecting public health on public transportation.
-																Together, our riders and employees can make this new
-																world we're traveling in a safer one. #RideSafer<br>
-																<br>
-																Learn more at mbta.com/RideSafer
-															</td>
-														</tr>
-													</tbody>
-												</table>
-
-
-
-
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
-									style="min-width:100%;">
-									<tbody class="mcnDividerBlockOuter">
-										<tr>
-											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
-												<table class="mcnDividerContent" border="0" cellpadding="0"
-													cellspacing="0" width="100%"
-													style="min-width: 100%;border-top: 2px none #EAEAEA;">
-													<tbody>
-														<tr>
-															<td>
-																<span></span>
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--            
-                <td class="mcnDividerBlockInner" style="padding: 18px;">
-                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
--->
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
-									style="min-width:100%;">
-									<tbody class="mcnTextBlockOuter">
-										<tr>
-											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
-												<!--[if mso]>
-				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
-				<tr>
-				<![endif]-->
-
-												<!--[if mso]>
-				<td valign="top" width="600" style="width:600px;">
-				<![endif]-->
-												<table align="left" border="0" cellpadding="0" cellspacing="0"
-													style="max-width:100%; min-width:100%;" width="100%"
-													class="mcnTextContentContainer">
-													<tbody>
-														<tr>
-
-															<td valign="top" class="mcnTextContent"
-																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
-
-																<h1 class="null" dir="ltr">Real Time Crowding
-																	Information</h1>
-
-																<p dir="ltr"><span style="font-size:18px"><span
-																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Crowding
-																			has become a vital consideration for many T
-																			riders. To address this and keep riders
-																			informed <a
-																				href="https://www.mbta.com/covid19"
-																				target="_blank">during the COVID-19
-																				outbreak</a>, we are piloting new
-																			real-time crowding information. This means
-																			riders can find live crowding information
-																			for more than 30 of our busiest bus routes
-																			on our website, <a
-																				href="http://www.mbta.com/eink"
-																				target="_blank">E Ink screens</a>, and
-																			in <a
-																				href="https://transitapp.com/download?utm_source=mbta-ma-website&amp;utm_medium=referral&amp;utm_campaign=partners"
-																				target="_blank">the Transit app</a>. We
-																			have prioritized making this information
-																			available on routes with notably high
-																			ridership during the pandemic. For each
-																			route, our Customer Technology team verifies
-																			the accuracy of real-time crowding
-																			information through manual passenger counts.
-																			We plan to add more routes throughout the
-																			summer.&nbsp;<br>
-																			<br>
-																			On our website, visit the schedule page for
-																			any route that has crowding information
-																			available, and then tap or click the vehicle
-																			icon on the map or the line diagram.<br>
-																			<br>
-																			<a href="https://www.mbta.com/projects/crowding-information-riders"
-																				target="_blank">See routes with crowding
-																				information</a></span></span></p>
-
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--[if mso]>
-				</td>
-				<![endif]-->
-
-												<!--[if mso]>
-				</tr>
-				</table>
-				<![endif]-->
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
-									style="min-width:100%;">
-									<tbody class="mcnDividerBlockOuter">
-										<tr>
-											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
-												<table class="mcnDividerContent" border="0" cellpadding="0"
-													cellspacing="0" width="100%"
-													style="min-width: 100%;border-top: 2px none #EAEAEA;">
-													<tbody>
-														<tr>
-															<td>
-																<span></span>
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--            
-                <td class="mcnDividerBlockInner" style="padding: 18px;">
-                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
--->
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
-									style="min-width:100%;">
-									<tbody class="mcnTextBlockOuter">
-										<tr>
-											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
-												<!--[if mso]>
-				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
-				<tr>
-				<![endif]-->
-
-												<!--[if mso]>
-				<td valign="top" width="600" style="width:600px;">
-				<![endif]-->
-												<table align="left" border="0" cellpadding="0" cellspacing="0"
-													style="max-width:100%; min-width:100%;" width="100%"
-													class="mcnTextContentContainer">
-													<tbody>
-														<tr>
-
-															<td valign="top" class="mcnTextContent"
-																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
-
-																<h1 class="null" dir="ltr">Return to Front Door Boarding
-																	for all Customers on Buses, Green Line &amp;
-																	Mattapan Trolley</h1>
-
-																<p dir="ltr"><span style="font-size:18px"><span
-																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">As
-																			of July 20, the MBTA has resumed front door
-																			boarding on all buses as well as trolleys on
-																			the Green Line and Mattapan Line. New
-																			protective barriers support physical
-																			distancing between operators and passengers,
-																			allowing front door boarding to resume.<br>
-																			<br>
-																			The MBTA may revisit boarding procedures
-																			should there be a substantial statewide
-																			increase in active COVID-19 cases. We will
-																			notify riders in advance if any changes
-																			become necessary.</span></span></p>
-
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--[if mso]>
-				</td>
-				<![endif]-->
-
-												<!--[if mso]>
-				</tr>
-				</table>
-				<![endif]-->
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
-									style="min-width:100%;">
-									<tbody class="mcnDividerBlockOuter">
-										<tr>
-											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
-												<table class="mcnDividerContent" border="0" cellpadding="0"
-													cellspacing="0" width="100%"
-													style="min-width: 100%;border-top: 2px none #EAEAEA;">
-													<tbody>
-														<tr>
-															<td>
-																<span></span>
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--            
-                <td class="mcnDividerBlockInner" style="padding: 18px;">
-                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
--->
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
-									style="min-width:100%;">
-									<tbody class="mcnTextBlockOuter">
-										<tr>
-											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
-												<!--[if mso]>
-				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
-				<tr>
-				<![endif]-->
-
-												<!--[if mso]>
-				<td valign="top" width="600" style="width:600px;">
-				<![endif]-->
-												<table align="left" border="0" cellpadding="0" cellspacing="0"
-													style="max-width:100%; min-width:100%;" width="100%"
-													class="mcnTextContentContainer">
-													<tbody>
-														<tr>
-
-															<td valign="top" class="mcnTextContent"
-																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
-
-																<h1 class="null" dir="ltr">Need Assistance within a
-																	Station?</h1>
-
-																<p dir="ltr"><span style="font-size:18px"><span
-																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Transit
-																			Ambassadors and other station officials are
-																			available to offer assistance at many MBTA
-																			stations. If an Ambassador is not available,
-																			you can use any station call box to request
-																			assistance. Common
-																			accessibility-relat</span>ed requests
-																		include:</span></p>
-
-																<ul dir="ltr">
-																	<li><span style="font-size:18px">Assistance boarding
-																			a vehicle (e.g., with a bridge plate)</span>
-																	</li>
-																	<li><span style="font-size:18px">Navigating a
-																			station</span></li>
-																	<li><span style="font-size:18px">Pressing elevator
-																			buttons</span></li>
-																	<li><span style="font-size:18px">Help finding a
-																			seat</span></li>
-																</ul>
-
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--[if mso]>
-				</td>
-				<![endif]-->
-
-												<!--[if mso]>
-				</tr>
-				</table>
-				<![endif]-->
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
-									style="min-width:100%;">
-									<tbody class="mcnDividerBlockOuter">
-										<tr>
-											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
-												<table class="mcnDividerContent" border="0" cellpadding="0"
-													cellspacing="0" width="100%"
-													style="min-width: 100%;border-top: 2px none #EAEAEA;">
-													<tbody>
-														<tr>
-															<td>
-																<span></span>
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--            
-                <td class="mcnDividerBlockInner" style="padding: 18px;">
-                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
--->
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
-									style="min-width:100%;">
-									<tbody class="mcnTextBlockOuter">
-										<tr>
-											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
-												<!--[if mso]>
-				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
-				<tr>
-				<![endif]-->
-
-												<!--[if mso]>
-				<td valign="top" width="600" style="width:600px;">
-				<![endif]-->
-												<table align="left" border="0" cellpadding="0" cellspacing="0"
-													style="max-width:100%; min-width:100%;" width="100%"
-													class="mcnTextContentContainer">
-													<tbody>
-														<tr>
-
-															<td valign="top" class="mcnTextContent"
-																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
-
-																<h1 class="null" dir="ltr">Continued Cleaning and
-																	Sanitizing of Vehicles and Stations</h1>
-
-																<p dir="ltr"><span style="font-size:18px"><span
-																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">We
-																			are continuing to take necessary steps to
-																			protect the health and safety of riders and
-																			MBTA employees with increased sanitation
-																			procedures. This includes:</span></span></p>
-
-																<ul dir="ltr">
-																	<li><span style="font-size:18px"><strong>Cleaning
-																				and disinfecting vehicles</strong>: All
-																			MBTA fleet vehicles (buses, trolleys, subway
-																			cars, Commuter Rail coaches, ferries, and
-																			RIDE vehicles) are disinfected on a daily
-																			basis.</span></li>
-																	<li><span style="font-size:18px"><span
-																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif"><strong>Cleaning
-																					and disinfecting MBTA
-																					property</strong>: All high-contact
-																				areas at subway stations (handrails,
-																				fare gates, and fare vending machines)
-																				are cleaned every 4 hours.</span></span>
-																	</li>
-																	<li><span style="font-size:18px"><span
-																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif"><strong>More
-																					sanitation equipment</strong>: Hand
-																				sanitizing dispensers, disinfectant
-																				wipes, and cleaning sprays are deployed
-																				at MBTA facilities and stations
-																				throughout the system.</span></span>
-																	</li>
-																</ul>
-
-																<p dir="ltr">&nbsp;</p>
-
-																<h2 class="null" dir="ltr">What You Can Do</h2>
-
-																<p dir="ltr"><span style="font-size:18px"><span
-																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">We
-																			encourage all riders to:</span></span></p>
-
-																<ul dir="ltr">
-																	<li><span style="font-size:18px">Wear face coverings
-																			while on public transit, as required in
-																			Massachusetts</span></li>
-																	<li><span style="font-size:18px"><span
-																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Wash
-																				hands often with soap and warm water for
-																				at least 20 seconds</span></span></li>
-																	<li><span style="font-size:18px"><span
-																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Cover
-																				coughs and sneezes</span></span></li>
-																	<li><span style="font-size:18px"><span
-																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Stay
-																				home if sick</span></span></li>
-																	<li><span style="font-size:18px"><span
-																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Avoid
-																				touching eyes, nose, and
-																				mouth</span></span></li>
-																	<li><span style="font-size:18px"><span
-																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Clean
-																				high-touch areas with sanitizing spray
-																				or wipes</span></span></li>
-																</ul>
-
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--[if mso]>
-				</td>
-				<![endif]-->
-
-												<!--[if mso]>
-				</tr>
-				</table>
-				<![endif]-->
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
-									style="min-width:100%;">
-									<tbody class="mcnDividerBlockOuter">
-										<tr>
-											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
-												<table class="mcnDividerContent" border="0" cellpadding="0"
-													cellspacing="0" width="100%"
-													style="min-width: 100%;border-top: 2px none #EAEAEA;">
-													<tbody>
-														<tr>
-															<td>
-																<span></span>
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--            
-                <td class="mcnDividerBlockInner" style="padding: 18px;">
-                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
--->
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
-									style="min-width:100%;">
-									<tbody class="mcnTextBlockOuter">
-										<tr>
-											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
-												<!--[if mso]>
-				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
-				<tr>
-				<![endif]-->
-
-												<!--[if mso]>
-				<td valign="top" width="600" style="width:600px;">
-				<![endif]-->
-												<table align="left" border="0" cellpadding="0" cellspacing="0"
-													style="max-width:100%; min-width:100%;" width="100%"
-													class="mcnTextContentContainer">
-													<tbody>
-														<tr>
-
-															<td valign="top" class="mcnTextContent"
-																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
-
-																<h1 class="null" dir="ltr">Need Help With Your Reduced
-																	Fare Card?</h1>
-
-																<p dir="ltr"><span style="font-size:18px"><span
-																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">The
-																			Charlie Card Store at Downtown Crossing
-																			remains closed. However, we are still
-																			working to process renewals, replace lost
-																			cards, and process new applications. For
-																			more information, visit <a
-																				href="http://www.mbta.com/fares/reduced"
-																				target="_blank">mbta.com/fares/reduced</a>,
-																			email the Charlie Card Store at <a
-																				href="mailto:CharlieCardStoreDept@MBTA.com"
-																				target="_blank">CharlieCardStoreDept@MBTA.com</a>,
-																			or call Customer Service at
-																			617-222-3200.</span></span></p>
-
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--[if mso]>
-				</td>
-				<![endif]-->
-
-												<!--[if mso]>
-				</tr>
-				</table>
-				<![endif]-->
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
-									style="min-width:100%;">
-									<tbody class="mcnDividerBlockOuter">
-										<tr>
-											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
-												<table class="mcnDividerContent" border="0" cellpadding="0"
-													cellspacing="0" width="100%"
-													style="min-width: 100%;border-top: 2px none #EAEAEA;">
-													<tbody>
-														<tr>
-															<td>
-																<span></span>
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--            
-                <td class="mcnDividerBlockInner" style="padding: 18px;">
-                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
--->
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
-									style="min-width:100%;">
-									<tbody class="mcnTextBlockOuter">
-										<tr>
-											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
-												<!--[if mso]>
-				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
-				<tr>
-				<![endif]-->
-
-												<!--[if mso]>
-				<td valign="top" width="600" style="width:600px;">
-				<![endif]-->
-												<table align="left" border="0" cellpadding="0" cellspacing="0"
-													style="max-width:100%; min-width:100%;" width="100%"
-													class="mcnTextContentContainer">
-													<tbody>
-														<tr>
-
-															<td valign="top" class="mcnTextContent"
-																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
-
-																<h1 class="null" dir="ltr">RIDE Policy Updates</h1>
-
-																<p dir="ltr"><span style="font-size:18px"><span
-																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">As
-																			of August 15th, the temporary offering that
-																			allowed a PCA to travel on The RIDE alone
-																			has been suspended. The RIDE has returned to
-																			its standard operating procedure of
-																			customers traveling with a PCA and/or a
-																			guest.<br>
-																			&nbsp;<br>
-																			Other operating procedures implemented in
-																			March remain in place. The RIDE continues to
-																			provide single trips for customers traveling
-																			with their PCA and/or guests. Trip
-																			reservations still must be made 1-3 days in
-																			advance, and we are working to eliminate
-																			transfer trips whenever possible. We clean
-																			and disinfect RIDE vehicles every 24 hours
-																			and require face coverings for all unless
-																			medically excused. The RIDE Eligibility
-																			Center (TREC) remains closed for in-person
-																			assessments but continues to operate
-																			remotely. TREC can be reached at
-																			617-337-2727 or <a
-																				href="mailto:trec@paratransit.org"
-																				target="_blank">trec@paratransit.org</a>
-																			for any eligibility questions or
-																			concerns.<br>
-																			<br>
-																			Stay safe and best regards,<br>
-																			<br>
-																			The Department of System-Wide
-																			Accessibility&nbsp;</span></span></p>
-
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--[if mso]>
-				</td>
-				<![endif]-->
-
-												<!--[if mso]>
-				</tr>
-				</table>
-				<![endif]-->
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
-									style="min-width:100%;">
-									<tbody class="mcnDividerBlockOuter">
-										<tr>
-											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
-												<table class="mcnDividerContent" border="0" cellpadding="0"
-													cellspacing="0" width="100%"
-													style="min-width: 100%;border-top: 2px none #EAEAEA;">
-													<tbody>
-														<tr>
-															<td>
-																<span></span>
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--            
-                <td class="mcnDividerBlockInner" style="padding: 18px;">
-                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
--->
-											</td>
-										</tr>
-									</tbody>
-								</table>
-								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnBoxedTextBlock"
-									style="min-width:100%;">
-									<!--[if gte mso 9]>
-	<table align="center" border="0" cellspacing="0" cellpadding="0" width="100%">
-	<![endif]-->
-									<tbody class="mcnBoxedTextBlockOuter">
-										<tr>
-											<td valign="top" class="mcnBoxedTextBlockInner">
-
-												<!--[if gte mso 9]>
-				<td align="center" valign="top" ">
-				<![endif]-->
-												<table align="left" border="0" cellpadding="0" cellspacing="0"
-													width="100%" style="min-width:100%;"
-													class="mcnBoxedTextContentContainer">
-													<tbody>
-														<tr>
-
-															<td
-																style="padding-top:9px; padding-left:18px; padding-bottom:9px; padding-right:18px;">
-
-																<table border="0" cellspacing="0"
-																	class="mcnTextContentContainer" width="100%"
-																	style="min-width: 100% !important;background-color: #F2F3F5;">
-																	<tbody>
-																		<tr>
-																			<td valign="top" class="mcnTextContent"
-																				style="padding: 18px;color: #222222;font-family: Helvetica;font-size: 14px;font-weight: normal;line-height: 150%;text-align: left;">
-																				<h1 class="null" dir="ltr">Get Involved
-																					with the Riders’ Transportation
-																					Access Group</h1>
-
-																				<p dir="ltr"
-																					style="color: #222222;font-family: Helvetica;font-size: 14px;font-weight: normal;line-height: 150%;text-align: left;">
-																					<span style="font-size:18px">The
-																						Riders’ Transportation Access
-																						Group (R-TAG) is a customer
-																						organization that advises the
-																						MBTA on issues of transportation
-																						and accessibility. Membership is
-																						open to the general public. To
-																						learn more, click the link below
-																						or attend an upcoming R-TAG
-																						meeting.<br>
-																						<br>
-																						<a href="https://www.mbta.com/accessibility/get-involved/rtag"
-																							target="_blank">Learn about
-																							R-TAG</a></span><br>
-																					&nbsp;</p>
-
-																				<h1 class="null" dir="ltr">Send Us Your
-																					Feedback&nbsp;</h1>
-
-																				<p dir="ltr"
-																					style="color: #222222;font-family: Helvetica;font-size: 14px;font-weight: normal;line-height: 150%;text-align: left;">
-																					<span style="font-size:18px">We want
-																						to hear from you! To share your
-																						concerns, questions, or positive
-																						experiences with us, please
-																						visit <a
-																							href="http://www.mbta.com/customer-support"
-																							target="_blank">mbta.com/customer-support</a>
-																						or call Customer Service at
-																						617-222-3200 (TTY:
-																						617-222-5146).</span><br>
-																					&nbsp;</p>
-
-																				<h1 class="null" dir="ltr">Learn More
-																					about Accessibility at the MBTA</h1>
-
-																				<p dir="ltr"
-																					style="color: #222222;font-family: Helvetica;font-size: 14px;font-weight: normal;line-height: 150%;text-align: left;">
-																					<span style="font-size:18px">We have
-																						numerous efforts underway to
-																						improve accessibility at the
-																						MBTA. Visit <a
-																							href="http://www.mbta.com/accessibility"
-																							target="_blank">mbta.com/accessibility</a>
-																						to learn more.</span></p>
-
-																			</td>
-																		</tr>
-																	</tbody>
-																</table>
-															</td>
-														</tr>
-													</tbody>
-												</table>
-												<!--[if gte mso 9]>
-				</td>
-				<![endif]-->
-
-												<!--[if gte mso 9]>
-                </tr>
-                </table>
-				<![endif]-->
-											</td>
+											<![endif]-->
 										</tr>
 									</tbody>
 								</table>
 							</td>
 						</tr>
-					</table>
-					<!--[if (gte mso 9)|(IE)]>
-                        </td>
-                        </tr>
-                        </table>
-                        <![endif]-->
 					<!-- // END TEMPLATE -->
 				</td>
 			</tr>
 		</table>
 	</center>
-	<script type="text/javascript" src="/u1xULUfspheluHE4VJj4/GYiu0DQVE9aa/QQAYAQ/Bm8/jOUFwIVwB"></script>
 </body>
 
 </html>

--- a/email.html
+++ b/email.html
@@ -1,0 +1,1789 @@
+<!doctype html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml"
+	xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+	<!-- NAME: 1 COLUMN -->
+	<!--[if gte mso 15]>
+        <xml>
+            <o:OfficeDocumentSettings>
+            <o:AllowPNG/>
+            <o:PixelsPerInch>96</o:PixelsPerInch>
+            </o:OfficeDocumentSettings>
+        </xml>
+        <![endif]-->
+	<meta charset="UTF-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>*|MC:SUBJECT|*</title>
+
+	<style type="text/css">
+		p {
+			margin: 10px 0;
+			padding: 0;
+		}
+
+		table {
+			border-collapse: collapse;
+		}
+
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			display: block;
+			margin: 0;
+			padding: 0;
+		}
+
+		img,
+		a img {
+			border: 0;
+			height: auto;
+			outline: none;
+			text-decoration: none;
+		}
+
+		body,
+		#bodyTable,
+		#bodyCell {
+			height: 100%;
+			margin: 0;
+			padding: 0;
+			width: 100%;
+		}
+
+		.mcnPreviewText {
+			display: none !important;
+		}
+
+		#outlook a {
+			padding: 0;
+		}
+
+		img {
+			-ms-interpolation-mode: bicubic;
+		}
+
+		table {
+			mso-table-lspace: 0pt;
+			mso-table-rspace: 0pt;
+		}
+
+		.ReadMsgBody {
+			width: 100%;
+		}
+
+		.ExternalClass {
+			width: 100%;
+		}
+
+		p,
+		a,
+		li,
+		td,
+		blockquote {
+			mso-line-height-rule: exactly;
+		}
+
+		a[href^=tel],
+		a[href^=sms] {
+			color: inherit;
+			cursor: default;
+			text-decoration: none;
+		}
+
+		p,
+		a,
+		li,
+		td,
+		body,
+		table,
+		blockquote {
+			-ms-text-size-adjust: 100%;
+			-webkit-text-size-adjust: 100%;
+		}
+
+		.ExternalClass,
+		.ExternalClass p,
+		.ExternalClass td,
+		.ExternalClass div,
+		.ExternalClass span,
+		.ExternalClass font {
+			line-height: 100%;
+		}
+
+		a[x-apple-data-detectors] {
+			color: inherit !important;
+			text-decoration: none !important;
+			font-size: inherit !important;
+			font-family: inherit !important;
+			font-weight: inherit !important;
+			line-height: inherit !important;
+		}
+
+		#bodyCell {
+			padding: 10px;
+		}
+
+		.templateContainer {
+			max-width: 600px !important;
+		}
+
+		a.mcnButton {
+			display: block;
+		}
+
+		.mcnImage,
+		.mcnRetinaImage {
+			vertical-align: bottom;
+		}
+
+		.mcnTextContent {
+			word-break: break-word;
+		}
+
+		.mcnTextContent img {
+			height: auto !important;
+		}
+
+		.mcnDividerBlock {
+			table-layout: fixed !important;
+		}
+
+		/*
+	@tab Page
+	@section Background Style
+	@tip Set the background color and top border for your email. You may want to choose colors that match your company's branding.
+	*/
+		body,
+		#bodyTable {
+			/*@editable*/
+			background-color: #ffffff;
+		}
+
+		/*
+	@tab Page
+	@section Background Style
+	@tip Set the background color and top border for your email. You may want to choose colors that match your company's branding.
+	*/
+		#bodyCell {
+			/*@editable*/
+			border-top: 0;
+		}
+
+		/*
+	@tab Page
+	@section Email Border
+	@tip Set the border for your email.
+	*/
+		.templateContainer {
+			/*@editable*/
+			border: 0;
+		}
+
+		/*
+	@tab Page
+	@section Heading 1
+	@tip Set the styling for all first-level headings in your emails. These should be the largest of your headings.
+	@style heading 1
+	*/
+		h1 {
+			/*@editable*/
+			color: #202020;
+			/*@editable*/
+			font-family: Helvetica;
+			/*@editable*/
+			font-size: 26px;
+			/*@editable*/
+			font-style: normal;
+			/*@editable*/
+			font-weight: bold;
+			/*@editable*/
+			line-height: 125%;
+			/*@editable*/
+			letter-spacing: normal;
+			/*@editable*/
+			text-align: left;
+		}
+
+		/*
+	@tab Page
+	@section Heading 2
+	@tip Set the styling for all second-level headings in your emails.
+	@style heading 2
+	*/
+		h2 {
+			/*@editable*/
+			color: #202020;
+			/*@editable*/
+			font-family: Helvetica;
+			/*@editable*/
+			font-size: 22px;
+			/*@editable*/
+			font-style: normal;
+			/*@editable*/
+			font-weight: bold;
+			/*@editable*/
+			line-height: 125%;
+			/*@editable*/
+			letter-spacing: normal;
+			/*@editable*/
+			text-align: left;
+		}
+
+		/*
+	@tab Page
+	@section Heading 3
+	@tip Set the styling for all third-level headings in your emails.
+	@style heading 3
+	*/
+		h3 {
+			/*@editable*/
+			color: #202020;
+			/*@editable*/
+			font-family: Helvetica;
+			/*@editable*/
+			font-size: 20px;
+			/*@editable*/
+			font-style: normal;
+			/*@editable*/
+			font-weight: bold;
+			/*@editable*/
+			line-height: 125%;
+			/*@editable*/
+			letter-spacing: normal;
+			/*@editable*/
+			text-align: left;
+		}
+
+		/*
+	@tab Page
+	@section Heading 4
+	@tip Set the styling for all fourth-level headings in your emails. These should be the smallest of your headings.
+	@style heading 4
+	*/
+		h4 {
+			/*@editable*/
+			color: #202020;
+			/*@editable*/
+			font-family: Helvetica;
+			/*@editable*/
+			font-size: 18px;
+			/*@editable*/
+			font-style: normal;
+			/*@editable*/
+			font-weight: bold;
+			/*@editable*/
+			line-height: 125%;
+			/*@editable*/
+			letter-spacing: normal;
+			/*@editable*/
+			text-align: left;
+		}
+
+		/*
+	@tab Preheader
+	@section Preheader Style
+	@tip Set the background color and borders for your email's preheader area.
+	*/
+		#templatePreheader {
+			/*@editable*/
+			background-color: #fafafa;
+			/*@editable*/
+			background-image: none;
+			/*@editable*/
+			background-repeat: no-repeat;
+			/*@editable*/
+			background-position: center;
+			/*@editable*/
+			background-size: cover;
+			/*@editable*/
+			border-top: 0;
+			/*@editable*/
+			border-bottom: 0;
+			/*@editable*/
+			padding-top: 9px;
+			/*@editable*/
+			padding-bottom: 9px;
+		}
+
+		/*
+	@tab Preheader
+	@section Preheader Text
+	@tip Set the styling for your email's preheader text. Choose a size and color that is easy to read.
+	*/
+		#templatePreheader .mcnTextContent,
+		#templatePreheader .mcnTextContent p {
+			/*@editable*/
+			color: #656565;
+			/*@editable*/
+			font-family: Helvetica;
+			/*@editable*/
+			font-size: 12px;
+			/*@editable*/
+			line-height: 150%;
+			/*@editable*/
+			text-align: left;
+		}
+
+		/*
+	@tab Preheader
+	@section Preheader Link
+	@tip Set the styling for your email's preheader links. Choose a color that helps them stand out from your text.
+	*/
+		#templatePreheader .mcnTextContent a,
+		#templatePreheader .mcnTextContent p a {
+			/*@editable*/
+			color: #656565;
+			/*@editable*/
+			font-weight: normal;
+			/*@editable*/
+			text-decoration: underline;
+		}
+
+		/*
+	@tab Header
+	@section Header Style
+	@tip Set the background color and borders for your email's header area.
+	*/
+		#templateHeader {
+			/*@editable*/
+			background-color: #FFFFFF;
+			/*@editable*/
+			background-image: none;
+			/*@editable*/
+			background-repeat: no-repeat;
+			/*@editable*/
+			background-position: center;
+			/*@editable*/
+			background-size: cover;
+			/*@editable*/
+			border-top: 0;
+			/*@editable*/
+			border-bottom: 0;
+			/*@editable*/
+			padding-top: 9px;
+			/*@editable*/
+			padding-bottom: 0;
+		}
+
+		/*
+	@tab Header
+	@section Header Text
+	@tip Set the styling for your email's header text. Choose a size and color that is easy to read.
+	*/
+		#templateHeader .mcnTextContent,
+		#templateHeader .mcnTextContent p {
+			/*@editable*/
+			color: #202020;
+			/*@editable*/
+			font-family: Helvetica;
+			/*@editable*/
+			font-size: 16px;
+			/*@editable*/
+			line-height: 150%;
+			/*@editable*/
+			text-align: left;
+		}
+
+		/*
+	@tab Header
+	@section Header Link
+	@tip Set the styling for your email's header links. Choose a color that helps them stand out from your text.
+	*/
+		#templateHeader .mcnTextContent a,
+		#templateHeader .mcnTextContent p a {
+			/*@editable*/
+			color: #007C89;
+			/*@editable*/
+			font-weight: normal;
+			/*@editable*/
+			text-decoration: underline;
+		}
+
+		/*
+	@tab Body
+	@section Body Style
+	@tip Set the background color and borders for your email's body area.
+	*/
+		#templateBody {
+			/*@editable*/
+			background-color: #ffffff;
+			/*@editable*/
+			background-image: none;
+			/*@editable*/
+			background-repeat: no-repeat;
+			/*@editable*/
+			background-position: center;
+			/*@editable*/
+			background-size: cover;
+			/*@editable*/
+			border-top: 0;
+			/*@editable*/
+			border-bottom: 2px solid #EAEAEA;
+			/*@editable*/
+			padding-top: 0;
+			/*@editable*/
+			padding-bottom: 9px;
+		}
+
+		/*
+	@tab Body
+	@section Body Text
+	@tip Set the styling for your email's body text. Choose a size and color that is easy to read.
+	*/
+		#templateBody .mcnTextContent,
+		#templateBody .mcnTextContent p {
+			/*@editable*/
+			color: #202020;
+			/*@editable*/
+			font-family: Helvetica;
+			/*@editable*/
+			font-size: 16px;
+			/*@editable*/
+			line-height: 150%;
+			/*@editable*/
+			text-align: left;
+		}
+
+		/*
+	@tab Body
+	@section Body Link
+	@tip Set the styling for your email's body links. Choose a color that helps them stand out from your text.
+	*/
+		#templateBody .mcnTextContent a,
+		#templateBody .mcnTextContent p a {
+			/*@editable*/
+			color: #165c96;
+			/*@editable*/
+			font-weight: normal;
+			/*@editable*/
+			text-decoration: underline;
+		}
+
+		/*
+	@tab Footer
+	@section Footer Style
+	@tip Set the background color and borders for your email's footer area.
+	*/
+		#templateFooter {
+			/*@editable*/
+			background-color: #FAFAFA;
+			/*@editable*/
+			background-image: none;
+			/*@editable*/
+			background-repeat: no-repeat;
+			/*@editable*/
+			background-position: center;
+			/*@editable*/
+			background-size: cover;
+			/*@editable*/
+			border-top: 0;
+			/*@editable*/
+			border-bottom: 0;
+			/*@editable*/
+			padding-top: 9px;
+			/*@editable*/
+			padding-bottom: 9px;
+		}
+
+		/*
+	@tab Footer
+	@section Footer Text
+	@tip Set the styling for your email's footer text. Choose a size and color that is easy to read.
+	*/
+		#templateFooter .mcnTextContent,
+		#templateFooter .mcnTextContent p {
+			/*@editable*/
+			color: #656565;
+			/*@editable*/
+			font-family: Helvetica;
+			/*@editable*/
+			font-size: 12px;
+			/*@editable*/
+			line-height: 150%;
+			/*@editable*/
+			text-align: center;
+		}
+
+		/*
+	@tab Footer
+	@section Footer Link
+	@tip Set the styling for your email's footer links. Choose a color that helps them stand out from your text.
+	*/
+		#templateFooter .mcnTextContent a,
+		#templateFooter .mcnTextContent p a {
+			/*@editable*/
+			color: #656565;
+			/*@editable*/
+			font-weight: normal;
+			/*@editable*/
+			text-decoration: underline;
+		}
+
+		@media only screen and (min-width:768px) {
+			.templateContainer {
+				width: 600px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			body,
+			table,
+			td,
+			p,
+			a,
+			li,
+			blockquote {
+				-webkit-text-size-adjust: none !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			body {
+				width: 100% !important;
+				min-width: 100% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcnRetinaImage {
+				max-width: 100% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcnImage {
+				width: 100% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			.mcnCartContainer,
+			.mcnCaptionTopContent,
+			.mcnRecContentContainer,
+			.mcnCaptionBottomContent,
+			.mcnTextContentContainer,
+			.mcnBoxedTextContentContainer,
+			.mcnImageGroupContentContainer,
+			.mcnCaptionLeftTextContentContainer,
+			.mcnCaptionRightTextContentContainer,
+			.mcnCaptionLeftImageContentContainer,
+			.mcnCaptionRightImageContentContainer,
+			.mcnImageCardLeftTextContentContainer,
+			.mcnImageCardRightTextContentContainer,
+			.mcnImageCardLeftImageContentContainer,
+			.mcnImageCardRightImageContentContainer {
+				max-width: 100% !important;
+				width: 100% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcnBoxedTextContentContainer {
+				min-width: 100% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcnImageGroupContent {
+				padding: 9px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			.mcnCaptionLeftContentOuter .mcnTextContent,
+			.mcnCaptionRightContentOuter .mcnTextContent {
+				padding-top: 9px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			.mcnImageCardTopImageContent,
+			.mcnCaptionBottomContent:last-child .mcnCaptionBottomImageContent,
+			.mcnCaptionBlockInner .mcnCaptionTopContent:last-child .mcnTextContent {
+				padding-top: 18px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcnImageCardBottomImageContent {
+				padding-bottom: 9px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcnImageGroupBlockInner {
+				padding-top: 0 !important;
+				padding-bottom: 0 !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcnImageGroupBlockOuter {
+				padding-top: 9px !important;
+				padding-bottom: 9px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			.mcnTextContent,
+			.mcnBoxedTextContentColumn {
+				padding-right: 18px !important;
+				padding-left: 18px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			.mcnImageCardLeftImageContent,
+			.mcnImageCardRightImageContent {
+				padding-right: 18px !important;
+				padding-bottom: 0 !important;
+				padding-left: 18px !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+			.mcpreview-image-uploader {
+				display: none !important;
+				width: 100% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+	@tab Mobile Styles
+	@section Heading 1
+	@tip Make the first-level headings larger in size for better readability on small screens.
+	*/
+			h1 {
+				/*@editable*/
+				font-size: 22px !important;
+				/*@editable*/
+				line-height: 125% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+	@tab Mobile Styles
+	@section Heading 2
+	@tip Make the second-level headings larger in size for better readability on small screens.
+	*/
+			h2 {
+				/*@editable*/
+				font-size: 20px !important;
+				/*@editable*/
+				line-height: 125% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+	@tab Mobile Styles
+	@section Heading 3
+	@tip Make the third-level headings larger in size for better readability on small screens.
+	*/
+			h3 {
+				/*@editable*/
+				font-size: 18px !important;
+				/*@editable*/
+				line-height: 125% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+	@tab Mobile Styles
+	@section Heading 4
+	@tip Make the fourth-level headings larger in size for better readability on small screens.
+	*/
+			h4 {
+				/*@editable*/
+				font-size: 16px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+	@tab Mobile Styles
+	@section Boxed Text
+	@tip Make the boxed text larger in size for better readability on small screens. We recommend a font size of at least 16px.
+	*/
+			.mcnBoxedTextContentContainer .mcnTextContent,
+			.mcnBoxedTextContentContainer .mcnTextContent p {
+				/*@editable*/
+				font-size: 14px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+	@tab Mobile Styles
+	@section Preheader Visibility
+	@tip Set the visibility of the email's preheader on small screens. You can hide it to save space.
+	*/
+			#templatePreheader {
+				/*@editable*/
+				display: block !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+	@tab Mobile Styles
+	@section Preheader Text
+	@tip Make the preheader text larger in size for better readability on small screens.
+	*/
+			#templatePreheader .mcnTextContent,
+			#templatePreheader .mcnTextContent p {
+				/*@editable*/
+				font-size: 14px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+	@tab Mobile Styles
+	@section Header Text
+	@tip Make the header text larger in size for better readability on small screens.
+	*/
+			#templateHeader .mcnTextContent,
+			#templateHeader .mcnTextContent p {
+				/*@editable*/
+				font-size: 16px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+	@tab Mobile Styles
+	@section Body Text
+	@tip Make the body text larger in size for better readability on small screens. We recommend a font size of at least 16px.
+	*/
+			#templateBody .mcnTextContent,
+			#templateBody .mcnTextContent p {
+				/*@editable*/
+				font-size: 16px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+
+		@media only screen and (max-width: 480px) {
+
+			/*
+	@tab Mobile Styles
+	@section Footer Text
+	@tip Make the footer content text larger in size for better readability on small screens.
+	*/
+			#templateFooter .mcnTextContent,
+			#templateFooter .mcnTextContent p {
+				/*@editable*/
+				font-size: 14px !important;
+				/*@editable*/
+				line-height: 150% !important;
+			}
+
+		}
+	</style>
+	<script>var w = window; if (w.performance || w.mozPerformance || w.msPerformance || w.webkitPerformance) { var d = document; AKSB = w.AKSB || {}, AKSB.q = AKSB.q || [], AKSB.mark = AKSB.mark || function (e, _) { AKSB.q.push(["mark", e, _ || (new Date).getTime()]) }, AKSB.measure = AKSB.measure || function (e, _, t) { AKSB.q.push(["measure", e, _, t || (new Date).getTime()]) }, AKSB.done = AKSB.done || function (e) { AKSB.q.push(["done", e]) }, AKSB.mark("firstbyte", (new Date).getTime()), AKSB.prof = { custid: "641057", ustr: "cookiepresent", originlat: "0", clientrtt: "9", ghostip: "184.25.148.149", ipv6: false, pct: "10", clientip: "130.44.174.102", requestid: "ac17ef", region: "39173", protocol: "h2", blver: 14, akM: "x", akN: "ae", akTT: "O", akTX: "1", akTI: "ac17ef", ai: "462050", ra: "false", pmgn: "", pmgi: "", pmp: "", qc: "" }, function (e) { var _ = d.createElement("script"); _.async = "async", _.src = e; var t = d.getElementsByTagName("script"), t = t[t.length - 1]; t.parentNode.insertBefore(_, t) }(("https:" === d.location.protocol ? "https:" : "http:") + "//ds-aksb-a.akamaihd.net/aksb.min.js") }</script>
+</head>
+
+<body>
+	<!--*|IF:MC_PREVIEW_TEXT|*-->
+	<!--[if !gte mso 9]><!----><span class="mcnPreviewText"
+		style="display:none; font-size:0px; line-height:0px; max-height:0px; max-width:0px; opacity:0; overflow:hidden; visibility:hidden; mso-hide:all;">*|MC_PREVIEW_TEXT|*</span>
+	<!--<![endif]-->
+	<!--*|END:IF|*-->
+	<center>
+		<table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable">
+			<tr>
+				<td align="center" valign="top" id="bodyCell">
+					<!-- BEGIN TEMPLATE // -->
+					<!--[if (gte mso 9)|(IE)]>
+                        <table align="center" border="0" cellspacing="0" cellpadding="0" width="600" style="width:600px;">
+                        <tr>
+                        <td align="center" valign="top" width="600" style="width:600px;">
+                        <![endif]-->
+					<table border="0" cellpadding="0" cellspacing="0" width="100%" class="templateContainer">
+						<tr>
+							<td valign="top" id="templateHeader">
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnBoxedTextBlock"
+									style="min-width:100%;">
+
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnImageBlock"
+									style="min-width:100%;">
+									<tbody class="mcnImageBlockOuter">
+										<tr>
+											<td valign="top" style="padding:9px" class="mcnImageBlockInner">
+												<table align="left" width="100%" border="0" cellpadding="0"
+													cellspacing="0" class="mcnImageContentContainer"
+													style="min-width:100%;">
+													<tbody>
+														<tr>
+															<td class="mcnImageContent" valign="top"
+																style="padding-right: 9px; padding-left: 9px; padding-top: 0; padding-bottom: 0; text-align:center;">
+
+
+																<img align="center"
+																	alt="Logo of the Massachusetts Bay Transportation Authority"
+																	src="https://gallery.mailchimp.com/d69747d5fc9f30fa7321ea932/images/bcf766a9-2f0e-4ac7-88ff-d303e92c9056.png"
+																	width="564"
+																	style="max-width:979px; padding-bottom: 0; display: inline !important; vertical-align: bottom;"
+																	class="mcnImage">
+
+
+															</td>
+														</tr>
+													</tbody>
+												</table>
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
+									style="min-width:100%;">
+									<tbody class="mcnDividerBlockOuter">
+										<tr>
+											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
+												<table class="mcnDividerContent" border="0" cellpadding="0"
+													cellspacing="0" width="100%"
+													style="min-width: 100%;border-top: 2px none #EAEAEA;">
+													<tbody>
+														<tr>
+															<td>
+																<span></span>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</td>
+						</tr>
+						<tr>
+							<td valign="top" id="templateBody">
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
+									style="min-width:100%;">
+									<tbody class="mcnTextBlockOuter">
+										<tr>
+											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+												<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+
+												<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+												<table align="left" border="0" cellpadding="0" cellspacing="0"
+													style="max-width:100%; min-width:100%;" width="100%"
+													class="mcnTextContentContainer">
+													<tbody>
+														<tr>
+
+															<td valign="top" class="mcnTextContent"
+																style="padding: 0px 18px 9px; font-family: &quot;Helvetica Neue&quot;, Helvetica, Arial, Verdana, sans-serif;">
+
+																<p dir="ltr"
+																	style="font-family: &quot;Helvetica Neue&quot;, Helvetica, Arial, Verdana, sans-serif;">
+																	<span style="font-size:18px"><span
+																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Hi
+																			all,<br>
+																			<br>
+																			As we enter the end of summer, we wanted to
+																			take the opportunity to share some important
+																			information about how the MBTA is ensuring
+																			that our services remain both safe and
+																			accessible.</span></span></p>
+
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--[if mso]>
+				</td>
+				<![endif]-->
+
+												<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
+									style="min-width:100%;">
+									<tbody class="mcnTextBlockOuter">
+										<tr>
+											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+												<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+
+												<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+												<table align="left" border="0" cellpadding="0" cellspacing="0"
+													style="max-width:100%; min-width:100%;" width="100%"
+													class="mcnTextContentContainer">
+													<tbody>
+														<tr>
+
+															<td valign="top" class="mcnTextContent"
+																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+
+																<h1 class="null" dir="ltr">Ride Safer</h1>
+
+																<p dir="ltr"><span style="font-size:18px"><span
+																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Check
+																			out <a href="http://www.mbta.com/ridesafer"
+																				target="_blank">mbta.com/ridesafer</a>&nbsp;for
+																			a collection of updates and frequently asked
+																			questions about the measures we've taken in
+																			response&nbsp;to COVID-19.</span></span></p>
+
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--[if mso]>
+				</td>
+				<![endif]-->
+
+												<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%"
+									class="mcnImageCardBlock">
+									<tbody class="mcnImageCardBlockOuter">
+										<tr>
+											<td class="mcnImageCardBlockInner" valign="top"
+												style="padding-top:9px; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+
+												<table align="right" border="0" cellpadding="0" cellspacing="0"
+													class="mcnImageCardBottomContent" width="100%"
+													style="background-color: #404040;">
+													<tbody>
+														<tr>
+															<td class="mcnImageCardBottomImageContent" align="left"
+																valign="top"
+																style="padding-top:0px; padding-right:0px; padding-bottom:0; padding-left:0px;">
+
+
+																<a href="https://www.youtube.com/watch?v=4Mu-YvdyDKM"
+																	title="" class="" target="">
+
+
+																	<img alt=""
+																		src="https://mcusercontent.com/d69747d5fc9f30fa7321ea932/video_thumbnails_new/b6e9f9791b462542c4fae53e4be54294.png"
+																		width="564" style="max-width:640px;"
+																		class="mcnImage">
+																</a>
+
+															</td>
+														</tr>
+														<tr>
+															<td class="mcnTextContent" valign="top"
+																style="padding: 9px 18px;color: #F2F2F2;font-family: Helvetica;font-size: 14px;font-weight: normal;text-align: center;"
+																width="546">
+																As service increases and more riders return to taking
+																the T, we all must share the responsibility of
+																protecting public health on public transportation.
+																Together, our riders and employees can make this new
+																world we're traveling in a safer one. #RideSafer<br>
+																<br>
+																Learn more at mbta.com/RideSafer
+															</td>
+														</tr>
+													</tbody>
+												</table>
+
+
+
+
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
+									style="min-width:100%;">
+									<tbody class="mcnDividerBlockOuter">
+										<tr>
+											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
+												<table class="mcnDividerContent" border="0" cellpadding="0"
+													cellspacing="0" width="100%"
+													style="min-width: 100%;border-top: 2px none #EAEAEA;">
+													<tbody>
+														<tr>
+															<td>
+																<span></span>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
+									style="min-width:100%;">
+									<tbody class="mcnTextBlockOuter">
+										<tr>
+											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+												<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+
+												<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+												<table align="left" border="0" cellpadding="0" cellspacing="0"
+													style="max-width:100%; min-width:100%;" width="100%"
+													class="mcnTextContentContainer">
+													<tbody>
+														<tr>
+
+															<td valign="top" class="mcnTextContent"
+																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+
+																<h1 class="null" dir="ltr">Real Time Crowding
+																	Information</h1>
+
+																<p dir="ltr"><span style="font-size:18px"><span
+																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Crowding
+																			has become a vital consideration for many T
+																			riders. To address this and keep riders
+																			informed <a
+																				href="https://www.mbta.com/covid19"
+																				target="_blank">during the COVID-19
+																				outbreak</a>, we are piloting new
+																			real-time crowding information. This means
+																			riders can find live crowding information
+																			for more than 30 of our busiest bus routes
+																			on our website, <a
+																				href="http://www.mbta.com/eink"
+																				target="_blank">E Ink screens</a>, and
+																			in <a
+																				href="https://transitapp.com/download?utm_source=mbta-ma-website&amp;utm_medium=referral&amp;utm_campaign=partners"
+																				target="_blank">the Transit app</a>. We
+																			have prioritized making this information
+																			available on routes with notably high
+																			ridership during the pandemic. For each
+																			route, our Customer Technology team verifies
+																			the accuracy of real-time crowding
+																			information through manual passenger counts.
+																			We plan to add more routes throughout the
+																			summer.&nbsp;<br>
+																			<br>
+																			On our website, visit the schedule page for
+																			any route that has crowding information
+																			available, and then tap or click the vehicle
+																			icon on the map or the line diagram.<br>
+																			<br>
+																			<a href="https://www.mbta.com/projects/crowding-information-riders"
+																				target="_blank">See routes with crowding
+																				information</a></span></span></p>
+
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--[if mso]>
+				</td>
+				<![endif]-->
+
+												<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
+									style="min-width:100%;">
+									<tbody class="mcnDividerBlockOuter">
+										<tr>
+											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
+												<table class="mcnDividerContent" border="0" cellpadding="0"
+													cellspacing="0" width="100%"
+													style="min-width: 100%;border-top: 2px none #EAEAEA;">
+													<tbody>
+														<tr>
+															<td>
+																<span></span>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
+									style="min-width:100%;">
+									<tbody class="mcnTextBlockOuter">
+										<tr>
+											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+												<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+
+												<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+												<table align="left" border="0" cellpadding="0" cellspacing="0"
+													style="max-width:100%; min-width:100%;" width="100%"
+													class="mcnTextContentContainer">
+													<tbody>
+														<tr>
+
+															<td valign="top" class="mcnTextContent"
+																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+
+																<h1 class="null" dir="ltr">Return to Front Door Boarding
+																	for all Customers on Buses, Green Line &amp;
+																	Mattapan Trolley</h1>
+
+																<p dir="ltr"><span style="font-size:18px"><span
+																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">As
+																			of July 20, the MBTA has resumed front door
+																			boarding on all buses as well as trolleys on
+																			the Green Line and Mattapan Line. New
+																			protective barriers support physical
+																			distancing between operators and passengers,
+																			allowing front door boarding to resume.<br>
+																			<br>
+																			The MBTA may revisit boarding procedures
+																			should there be a substantial statewide
+																			increase in active COVID-19 cases. We will
+																			notify riders in advance if any changes
+																			become necessary.</span></span></p>
+
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--[if mso]>
+				</td>
+				<![endif]-->
+
+												<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
+									style="min-width:100%;">
+									<tbody class="mcnDividerBlockOuter">
+										<tr>
+											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
+												<table class="mcnDividerContent" border="0" cellpadding="0"
+													cellspacing="0" width="100%"
+													style="min-width: 100%;border-top: 2px none #EAEAEA;">
+													<tbody>
+														<tr>
+															<td>
+																<span></span>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
+									style="min-width:100%;">
+									<tbody class="mcnTextBlockOuter">
+										<tr>
+											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+												<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+
+												<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+												<table align="left" border="0" cellpadding="0" cellspacing="0"
+													style="max-width:100%; min-width:100%;" width="100%"
+													class="mcnTextContentContainer">
+													<tbody>
+														<tr>
+
+															<td valign="top" class="mcnTextContent"
+																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+
+																<h1 class="null" dir="ltr">Need Assistance within a
+																	Station?</h1>
+
+																<p dir="ltr"><span style="font-size:18px"><span
+																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Transit
+																			Ambassadors and other station officials are
+																			available to offer assistance at many MBTA
+																			stations. If an Ambassador is not available,
+																			you can use any station call box to request
+																			assistance. Common
+																			accessibility-relat</span>ed requests
+																		include:</span></p>
+
+																<ul dir="ltr">
+																	<li><span style="font-size:18px">Assistance boarding
+																			a vehicle (e.g., with a bridge plate)</span>
+																	</li>
+																	<li><span style="font-size:18px">Navigating a
+																			station</span></li>
+																	<li><span style="font-size:18px">Pressing elevator
+																			buttons</span></li>
+																	<li><span style="font-size:18px">Help finding a
+																			seat</span></li>
+																</ul>
+
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--[if mso]>
+				</td>
+				<![endif]-->
+
+												<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
+									style="min-width:100%;">
+									<tbody class="mcnDividerBlockOuter">
+										<tr>
+											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
+												<table class="mcnDividerContent" border="0" cellpadding="0"
+													cellspacing="0" width="100%"
+													style="min-width: 100%;border-top: 2px none #EAEAEA;">
+													<tbody>
+														<tr>
+															<td>
+																<span></span>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
+									style="min-width:100%;">
+									<tbody class="mcnTextBlockOuter">
+										<tr>
+											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+												<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+
+												<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+												<table align="left" border="0" cellpadding="0" cellspacing="0"
+													style="max-width:100%; min-width:100%;" width="100%"
+													class="mcnTextContentContainer">
+													<tbody>
+														<tr>
+
+															<td valign="top" class="mcnTextContent"
+																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+
+																<h1 class="null" dir="ltr">Continued Cleaning and
+																	Sanitizing of Vehicles and Stations</h1>
+
+																<p dir="ltr"><span style="font-size:18px"><span
+																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">We
+																			are continuing to take necessary steps to
+																			protect the health and safety of riders and
+																			MBTA employees with increased sanitation
+																			procedures. This includes:</span></span></p>
+
+																<ul dir="ltr">
+																	<li><span style="font-size:18px"><strong>Cleaning
+																				and disinfecting vehicles</strong>: All
+																			MBTA fleet vehicles (buses, trolleys, subway
+																			cars, Commuter Rail coaches, ferries, and
+																			RIDE vehicles) are disinfected on a daily
+																			basis.</span></li>
+																	<li><span style="font-size:18px"><span
+																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif"><strong>Cleaning
+																					and disinfecting MBTA
+																					property</strong>: All high-contact
+																				areas at subway stations (handrails,
+																				fare gates, and fare vending machines)
+																				are cleaned every 4 hours.</span></span>
+																	</li>
+																	<li><span style="font-size:18px"><span
+																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif"><strong>More
+																					sanitation equipment</strong>: Hand
+																				sanitizing dispensers, disinfectant
+																				wipes, and cleaning sprays are deployed
+																				at MBTA facilities and stations
+																				throughout the system.</span></span>
+																	</li>
+																</ul>
+
+																<p dir="ltr">&nbsp;</p>
+
+																<h2 class="null" dir="ltr">What You Can Do</h2>
+
+																<p dir="ltr"><span style="font-size:18px"><span
+																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">We
+																			encourage all riders to:</span></span></p>
+
+																<ul dir="ltr">
+																	<li><span style="font-size:18px">Wear face coverings
+																			while on public transit, as required in
+																			Massachusetts</span></li>
+																	<li><span style="font-size:18px"><span
+																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Wash
+																				hands often with soap and warm water for
+																				at least 20 seconds</span></span></li>
+																	<li><span style="font-size:18px"><span
+																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Cover
+																				coughs and sneezes</span></span></li>
+																	<li><span style="font-size:18px"><span
+																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Stay
+																				home if sick</span></span></li>
+																	<li><span style="font-size:18px"><span
+																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Avoid
+																				touching eyes, nose, and
+																				mouth</span></span></li>
+																	<li><span style="font-size:18px"><span
+																				style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">Clean
+																				high-touch areas with sanitizing spray
+																				or wipes</span></span></li>
+																</ul>
+
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--[if mso]>
+				</td>
+				<![endif]-->
+
+												<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
+									style="min-width:100%;">
+									<tbody class="mcnDividerBlockOuter">
+										<tr>
+											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
+												<table class="mcnDividerContent" border="0" cellpadding="0"
+													cellspacing="0" width="100%"
+													style="min-width: 100%;border-top: 2px none #EAEAEA;">
+													<tbody>
+														<tr>
+															<td>
+																<span></span>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
+									style="min-width:100%;">
+									<tbody class="mcnTextBlockOuter">
+										<tr>
+											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+												<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+
+												<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+												<table align="left" border="0" cellpadding="0" cellspacing="0"
+													style="max-width:100%; min-width:100%;" width="100%"
+													class="mcnTextContentContainer">
+													<tbody>
+														<tr>
+
+															<td valign="top" class="mcnTextContent"
+																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+
+																<h1 class="null" dir="ltr">Need Help With Your Reduced
+																	Fare Card?</h1>
+
+																<p dir="ltr"><span style="font-size:18px"><span
+																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">The
+																			Charlie Card Store at Downtown Crossing
+																			remains closed. However, we are still
+																			working to process renewals, replace lost
+																			cards, and process new applications. For
+																			more information, visit <a
+																				href="http://www.mbta.com/fares/reduced"
+																				target="_blank">mbta.com/fares/reduced</a>,
+																			email the Charlie Card Store at <a
+																				href="mailto:CharlieCardStoreDept@MBTA.com"
+																				target="_blank">CharlieCardStoreDept@MBTA.com</a>,
+																			or call Customer Service at
+																			617-222-3200.</span></span></p>
+
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--[if mso]>
+				</td>
+				<![endif]-->
+
+												<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
+									style="min-width:100%;">
+									<tbody class="mcnDividerBlockOuter">
+										<tr>
+											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
+												<table class="mcnDividerContent" border="0" cellpadding="0"
+													cellspacing="0" width="100%"
+													style="min-width: 100%;border-top: 2px none #EAEAEA;">
+													<tbody>
+														<tr>
+															<td>
+																<span></span>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
+									style="min-width:100%;">
+									<tbody class="mcnTextBlockOuter">
+										<tr>
+											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+												<!--[if mso]>
+				<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+				<tr>
+				<![endif]-->
+
+												<!--[if mso]>
+				<td valign="top" width="600" style="width:600px;">
+				<![endif]-->
+												<table align="left" border="0" cellpadding="0" cellspacing="0"
+													style="max-width:100%; min-width:100%;" width="100%"
+													class="mcnTextContentContainer">
+													<tbody>
+														<tr>
+
+															<td valign="top" class="mcnTextContent"
+																style="padding-top:0; padding-right:18px; padding-bottom:9px; padding-left:18px;">
+
+																<h1 class="null" dir="ltr">RIDE Policy Updates</h1>
+
+																<p dir="ltr"><span style="font-size:18px"><span
+																			style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">As
+																			of August 15th, the temporary offering that
+																			allowed a PCA to travel on The RIDE alone
+																			has been suspended. The RIDE has returned to
+																			its standard operating procedure of
+																			customers traveling with a PCA and/or a
+																			guest.<br>
+																			&nbsp;<br>
+																			Other operating procedures implemented in
+																			March remain in place. The RIDE continues to
+																			provide single trips for customers traveling
+																			with their PCA and/or guests. Trip
+																			reservations still must be made 1-3 days in
+																			advance, and we are working to eliminate
+																			transfer trips whenever possible. We clean
+																			and disinfect RIDE vehicles every 24 hours
+																			and require face coverings for all unless
+																			medically excused. The RIDE Eligibility
+																			Center (TREC) remains closed for in-person
+																			assessments but continues to operate
+																			remotely. TREC can be reached at
+																			617-337-2727 or <a
+																				href="mailto:trec@paratransit.org"
+																				target="_blank">trec@paratransit.org</a>
+																			for any eligibility questions or
+																			concerns.<br>
+																			<br>
+																			Stay safe and best regards,<br>
+																			<br>
+																			The Department of System-Wide
+																			Accessibility&nbsp;</span></span></p>
+
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--[if mso]>
+				</td>
+				<![endif]-->
+
+												<!--[if mso]>
+				</tr>
+				</table>
+				<![endif]-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnDividerBlock"
+									style="min-width:100%;">
+									<tbody class="mcnDividerBlockOuter">
+										<tr>
+											<td class="mcnDividerBlockInner" style="min-width:100%; padding:18px;">
+												<table class="mcnDividerContent" border="0" cellpadding="0"
+													cellspacing="0" width="100%"
+													style="min-width: 100%;border-top: 2px none #EAEAEA;">
+													<tbody>
+														<tr>
+															<td>
+																<span></span>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--            
+                <td class="mcnDividerBlockInner" style="padding: 18px;">
+                <hr class="mcnDividerContent" style="border-bottom-color:none; border-left-color:none; border-right-color:none; border-bottom-width:0; border-left-width:0; border-right-width:0; margin-top:0; margin-right:0; margin-bottom:0; margin-left:0;" />
+-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnBoxedTextBlock"
+									style="min-width:100%;">
+									<!--[if gte mso 9]>
+	<table align="center" border="0" cellspacing="0" cellpadding="0" width="100%">
+	<![endif]-->
+									<tbody class="mcnBoxedTextBlockOuter">
+										<tr>
+											<td valign="top" class="mcnBoxedTextBlockInner">
+
+												<!--[if gte mso 9]>
+				<td align="center" valign="top" ">
+				<![endif]-->
+												<table align="left" border="0" cellpadding="0" cellspacing="0"
+													width="100%" style="min-width:100%;"
+													class="mcnBoxedTextContentContainer">
+													<tbody>
+														<tr>
+
+															<td
+																style="padding-top:9px; padding-left:18px; padding-bottom:9px; padding-right:18px;">
+
+																<table border="0" cellspacing="0"
+																	class="mcnTextContentContainer" width="100%"
+																	style="min-width: 100% !important;background-color: #F2F3F5;">
+																	<tbody>
+																		<tr>
+																			<td valign="top" class="mcnTextContent"
+																				style="padding: 18px;color: #222222;font-family: Helvetica;font-size: 14px;font-weight: normal;line-height: 150%;text-align: left;">
+																				<h1 class="null" dir="ltr">Get Involved
+																					with the Riders’ Transportation
+																					Access Group</h1>
+
+																				<p dir="ltr"
+																					style="color: #222222;font-family: Helvetica;font-size: 14px;font-weight: normal;line-height: 150%;text-align: left;">
+																					<span style="font-size:18px">The
+																						Riders’ Transportation Access
+																						Group (R-TAG) is a customer
+																						organization that advises the
+																						MBTA on issues of transportation
+																						and accessibility. Membership is
+																						open to the general public. To
+																						learn more, click the link below
+																						or attend an upcoming R-TAG
+																						meeting.<br>
+																						<br>
+																						<a href="https://www.mbta.com/accessibility/get-involved/rtag"
+																							target="_blank">Learn about
+																							R-TAG</a></span><br>
+																					&nbsp;</p>
+
+																				<h1 class="null" dir="ltr">Send Us Your
+																					Feedback&nbsp;</h1>
+
+																				<p dir="ltr"
+																					style="color: #222222;font-family: Helvetica;font-size: 14px;font-weight: normal;line-height: 150%;text-align: left;">
+																					<span style="font-size:18px">We want
+																						to hear from you! To share your
+																						concerns, questions, or positive
+																						experiences with us, please
+																						visit <a
+																							href="http://www.mbta.com/customer-support"
+																							target="_blank">mbta.com/customer-support</a>
+																						or call Customer Service at
+																						617-222-3200 (TTY:
+																						617-222-5146).</span><br>
+																					&nbsp;</p>
+
+																				<h1 class="null" dir="ltr">Learn More
+																					about Accessibility at the MBTA</h1>
+
+																				<p dir="ltr"
+																					style="color: #222222;font-family: Helvetica;font-size: 14px;font-weight: normal;line-height: 150%;text-align: left;">
+																					<span style="font-size:18px">We have
+																						numerous efforts underway to
+																						improve accessibility at the
+																						MBTA. Visit <a
+																							href="http://www.mbta.com/accessibility"
+																							target="_blank">mbta.com/accessibility</a>
+																						to learn more.</span></p>
+
+																			</td>
+																		</tr>
+																	</tbody>
+																</table>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+												<!--[if gte mso 9]>
+				</td>
+				<![endif]-->
+
+												<!--[if gte mso 9]>
+                </tr>
+                </table>
+				<![endif]-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</td>
+						</tr>
+					</table>
+					<!--[if (gte mso 9)|(IE)]>
+                        </td>
+                        </tr>
+                        </table>
+                        <![endif]-->
+					<!-- // END TEMPLATE -->
+				</td>
+			</tr>
+		</table>
+	</center>
+	<script type="text/javascript" src="/u1xULUfspheluHE4VJj4/GYiu0DQVE9aa/QQAYAQ/Bm8/jOUFwIVwB"></script>
+</body>
+
+</html>


### PR DESCRIPTION
This PR adds a static email template to the repository, using a MailChimp SWA template as a starting point. I kept this short and simple following conversation with Ryan--only the logo and some text that can be used as a placeholder. I didn't make any edits to the style section (through line 842), only the HTML content of the email. 