### PR TITLE
Fix: Adjust form error, Add message types

### DIFF
--- a/assets/stylesheet.css
+++ b/assets/stylesheet.css
@@ -119,13 +119,33 @@ h1 {
     margin: -1px;
 }
 
-.form-error-container {
-    border: 2px solid #b3000f;
+.form-message-container {
+    border: 2px solid;
     border-radius: 4px;
-    color: #b3000f;
-    background: #F2DEDE;
     padding: 12px;
     text-align: left;
+}
+
+.form-error {
+    border-color: #b3000f;
+    color: #b3000f;
+    background: #F2DEDE;
+}
+
+.form-success {
+    border-color: #145A06;
+    color: #145A06;
+    background: #DFF0D8;
+}
+
+.form-warning {
+    border-color: #FFDD00;
+    background: rgb(255, 247, 191);
+}
+
+.form-info {
+    border-color: #D8DFE6;
+    background: rgb(242, 243, 245);
 }
 
 .form-input:focus, .form-input:hover {

--- a/login.html
+++ b/login.html
@@ -12,15 +12,15 @@
             <img id="logo" src="assets/images/MBTA_logo_text.svg" alt="MBTA logo">
             <h1>Sign In To Your Account</h1>
             <div class="container">
-                <form action="">
-                    <div class="form-group">
-                        <div class="form-error-container" role="alert">
-                            <strong class="error-summary">Please correct the following issues:</strong>
-                            <ul>
-                                <li class="error-message">The password field is required.</li>
-                            </ul>
-                        </div>
+                <div class="form-group">
+                    <div class="form-error-container" role="alert">
+                        <strong class="error-summary">Please correct the following issues:</strong>
+                        <ul>
+                            <li class="error-message">The password field is required.</li>
+                        </ul>
                     </div>
+                </div>
+                <form action="">
                     <div class="form-group">
                         <label class="form-input-label" for="form-input-email">Username or email</label>
                         <input 

--- a/login.html
+++ b/login.html
@@ -13,10 +13,34 @@
             <h1>Sign In To Your Account</h1>
             <div class="container">
                 <div class="form-group">
-                    <div class="form-error-container" role="alert">
-                        <strong class="error-summary">Please correct the following issues:</strong>
+                    <div class="form-message-container form-error" role="alert">
+                        <strong class="form-message-summary">Please correct the following issues:</strong>
                         <ul>
-                            <li class="error-message">The password field is required.</li>
+                            <li class="form-message-text">The password field is required.</li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="form-message-container form-success" role="alert">
+                        <strong class="form-message-summary">Success!</strong>
+                        <ul>
+                            <li class="form-message-text">Your login was successful.</li>
+                        </ul>                    
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="form-message-container form-warning" role="alert">
+                        <strong class="form-message-summary">Warning!</strong>
+                        <ul>
+                            <li class="form-message-text">Caps lock is enabled.</li>
+                        </ul>
+                    </div>
+                </div>
+                <div class="form-group">
+                    <div class="form-message-container form-info" role="alert">
+                        <strong class="form-message-summary">Please be aware of the following:</strong>
+                        <ul>
+                            <li class="form-message-text">Our site is undergoing maintenance.</li>
                         </ul>
                     </div>
                 </div>


### PR DESCRIPTION
This PR adds three additional message types (success, warning, info) and also moves the message container outside of the `form` element per IntegSoft request. There is no mockup for this in the SSO annotation slides. I used high- and low-priority alert colors for the Warning and Info messages, respectively. 

Asana ticket containing requests: https://app.asana.com/0/0/1200981513142981/1201451067556555

![Screen Shot 2021-12-02 at 12 07 38 PM](https://user-images.githubusercontent.com/49254078/144470006-113c3c79-3685-4c14-a56f-5b075cd3f1e6.png)
/f